### PR TITLE
fix: correct concat error in register_cli_args

### DIFF
--- a/snakemake_storage_plugin_azure/__init__.py
+++ b/snakemake_storage_plugin_azure/__init__.py
@@ -86,10 +86,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
     access_key: Optional[str] = field(
         default=None,
         metadata={
-            "help": (
-                "Azure Blob Storage Account Access Key Credential.",
-                "If set, takes precedence over sas_token credential.",
-            ),
+            "help": "Azure Blob Storage Account Access Key Credential.\nIf set, takes precedence over sas_token credential.",
             "env_var": False,
         },
     )


### PR DESCRIPTION
Fix issue #2635

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/snakemake/cli.py", line 2038, in main
    parser, args = parse_args(argv)
                   ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/snakemake/cli.py", line 1628, in parse_args
    parser = get_argument_parser()
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/snakemake/cli.py", line 1611, in get_argument_parser
    StoragePluginRegistry().register_cli_args(parser)
  File "/usr/local/lib/python3.11/dist-packages/snakemake_interface_common/plugin_registry/__init__.py", line 60, in register_cli_args
    plugin.register_cli_args(argparser)
  File "/usr/local/lib/python3.11/dist-packages/snakemake_interface_common/plugin_registry/plugin.py", line 149, in register_cli_args
    kwargs["help"] += (
TypeError: can only concatenate tuple (not "str") to tuple
```