### PR TITLE
feat: use credential chain to prefer cli credential

### DIFF
--- a/snakemake_storage_plugin_azure/__init__.py
+++ b/snakemake_storage_plugin_azure/__init__.py
@@ -3,7 +3,12 @@ from dataclasses import dataclass, field
 from typing import Iterable, List, Optional
 from urllib.parse import urlparse
 
-from azure.identity import DefaultAzureCredential
+from azure.identity import (
+    AzureCliCredential,
+    ManagedIdentityCredential,
+    EnvironmentCredential,
+    ChainedTokenCredential
+)
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 from snakemake_interface_storage_plugins.common import Operation
 from snakemake_interface_storage_plugins.io import IOCacheStorageInterface, Mtime
@@ -81,8 +86,17 @@ class StorageProvider(StorageProviderBase):
                 test_credential
             )
         else:
+
+            # prefer azure cli credential, 
+            # then managed identity,
+            # then environment
+            credential_chain = (
+                AzureCliCredential(),
+                ManagedIdentityCredential(),
+                EnvironmentCredential()
+            )
             self.blob_account_client = BlobServiceClient(
-                endpoint_url, credential=DefaultAzureCredential()
+                endpoint_url, credential=ChainedTokenCredential(*credential_chain)
             )
 
     def use_rate_limiter(self) -> bool:

--- a/snakemake_storage_plugin_azure/__init__.py
+++ b/snakemake_storage_plugin_azure/__init__.py
@@ -5,9 +5,9 @@ from urllib.parse import urlparse
 
 from azure.identity import (
     AzureCliCredential,
-    ManagedIdentityCredential,
+    ChainedTokenCredential,
     EnvironmentCredential,
-    ChainedTokenCredential
+    ManagedIdentityCredential,
 )
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 from snakemake_interface_storage_plugins.common import Operation
@@ -86,14 +86,13 @@ class StorageProvider(StorageProviderBase):
                 test_credential
             )
         else:
-
-            # prefer azure cli credential, 
+            # prefer azure cli credential,
             # then managed identity,
             # then environment
             credential_chain = (
                 AzureCliCredential(),
                 ManagedIdentityCredential(),
-                EnvironmentCredential()
+                EnvironmentCredential(),
             )
             self.blob_account_client = BlobServiceClient(
                 endpoint_url, credential=ChainedTokenCredential(*credential_chain)


### PR DESCRIPTION
This PR replaces DefaultAzureCredential with a custom credential chain that prefers the AzureCLI credential over the ManagedIdentityCredential